### PR TITLE
Features/1100 flexible operator

### DIFF
--- a/airflow_ext/gfw/operators/helper/flexible_operator.py
+++ b/airflow_ext/gfw/operators/helper/flexible_operator.py
@@ -36,9 +36,9 @@ class FlexibleOperator:
         else:
             assert self.operator_parameters['name']
             assert self.operator_parameters['dag']
-            self.operator_parameters.update(get_logs=True, in_cluster=True)
+            self.operator_parameters.update(get_logs=True, in_cluster=True, pool='k8operators_limit')
             # Left only the extra parameters that are not the kubernetes_command
-            extra_params = { k : self.operator_parameters[k] for k in set(self.operator_parameters) - set(dict.fromkeys({'image','docker_run','name'})) }
+            extra_params = { k : self.operator_parameters[k] for k in set(self.operator_parameters) - set(dict.fromkeys({'image','docker_run','name','pool'})) }
             operator = KubernetesPodOperator(
                 namespace = os.getenv('K8_NAMESPACE'),
                 image = self.operator_parameters['image'],

--- a/airflow_ext/gfw/operators/helper/flexible_operator.py
+++ b/airflow_ext/gfw/operators/helper/flexible_operator.py
@@ -1,0 +1,44 @@
+from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
+from airflow.operators.bash_operator import BashOperator
+
+import os
+
+
+class FlexibleOperator:
+    def __init__(self, parameters):
+        self.operator_parameters = parameters
+
+    def build_operator(self, kind):
+        if kind != 'bash' or kind != 'kubernetes':
+            raise ValueError('The operators allowed are bash or kubernetes, not <{}>'.format(kind))
+        operator = None
+        task_id = self.operator_parameters['task_id']
+        pool = self.operator_parameters['pool']
+        cmds = self.operator_parameters['cmds']
+        if kind == 'bash':
+            commands = '{} {} {}'.format(
+                self.operator_parameters['docker_run'],
+                self.operator_parameters['image'],
+                ' '.join(cmds))
+            operator = BashOperator(
+                task_id = task_id,
+                pool = pool,
+                bash_command = commands
+            )
+        else:
+            commands = ['./scripts/run.sh']
+            commands.append(cmds)
+            operator = KubernetesPodOperator(
+                image = self.operator_parameters['image'],
+                name = self.operator_parameters['name'],
+                dag = self.operator_parameters['dag'],
+                cmds = commands,
+                namespace = os.getenv('K8_NAMESPACE'),
+                task_id = task_id,
+                pool = pool,
+                get_logs = True,
+                in_cluster = True
+            )
+        return operator
+
+

--- a/airflow_ext/gfw/operators/helper/flexible_operator.py
+++ b/airflow_ext/gfw/operators/helper/flexible_operator.py
@@ -27,7 +27,7 @@ class FlexibleOperator:
                 self.operator_parameters['image'],
                 ' '.join(cmds))
             # Left only the extra parameters that are not the bash_command
-            extra_params = { k : self.operator_parameters[k] for k in set(self.operator_parameters) - set(dict.fromkeys({'cmds','image','docker_run'})) }
+            extra_params = { k : self.operator_parameters[k] for k in set(self.operator_parameters) - set(dict.fromkeys({'cmds','image','docker_run','name','dag'})) }
             operator = BashOperator(
                 bash_command = commands,
                 **extra_params
@@ -35,19 +35,14 @@ class FlexibleOperator:
         else:
             assert self.operator_parameters['name']
             assert self.operator_parameters['dag']
-            commands = ['./scripts/run.sh']
-            commands.append(cmds)
+            self.operator_parameters['cmds'].insert(0, './scripts/run.sh')
+            self.operator_parameters.update(get_logs=True, in_cluster=True)
+            # Left only the extra parameters that are not the kubernetes_command
+            extra_params = { k : self.operator_parameters[k] for k in set(self.operator_parameters) - set(dict.fromkeys({'image','docker_run','name'})) }
             operator = KubernetesPodOperator(
                 namespace = os.getenv('K8_NAMESPACE'),
                 image = self.operator_parameters['image'],
                 name = self.operator_parameters['name'],
-                dag = self.operator_parameters['dag'],
-                cmds = commands,
-                task_id = task_id,
-                pool = pool,
-                get_logs = True,
-                in_cluster = True
+                **extra_params
             )
         return operator
-
-

--- a/airflow_ext/gfw/operators/helper/flexible_operator.py
+++ b/airflow_ext/gfw/operators/helper/flexible_operator.py
@@ -42,7 +42,6 @@ class FlexibleOperator:
             self.operator_parameters.update(get_logs=True, in_cluster=True)
             # Left only the extra parameters that are not the kubernetes_command
             extra_params = { k : self.operator_parameters[k] for k in set(self.operator_parameters) - set(dict.fromkeys({'image','docker_run','name'})) }
-            print '>>>>>>>> EXTRA PARAMTERS FOR KUBERNETES {}'.format(self.operator_parameters)
             operator = KubernetesPodOperator(
                 namespace = os.getenv('K8_NAMESPACE'),
                 image = self.operator_parameters['image'],

--- a/airflow_ext/gfw/operators/helper/flexible_operator.py
+++ b/airflow_ext/gfw/operators/helper/flexible_operator.py
@@ -6,26 +6,35 @@ import os
 
 class FlexibleOperator:
     def __init__(self, parameters):
+        assert parameters
         self.operator_parameters = parameters
 
     def build_operator(self, kind):
         if kind != 'bash' or kind != 'kubernetes':
             raise ValueError('The operators allowed are bash or kubernetes, not <{}>'.format(kind))
-        operator = None
+        assert self.operator_parameters['task_id']
+        assert self.operator_parameters['pool']
+        assert self.operator_parameters['cmds']
+        assert self.operator_parameters['image']
         task_id = self.operator_parameters['task_id']
         pool = self.operator_parameters['pool']
         cmds = self.operator_parameters['cmds']
+        operator = None
         if kind == 'bash':
+            assert self.operator_parameters['docker_run']
             commands = '{} {} {}'.format(
                 self.operator_parameters['docker_run'],
                 self.operator_parameters['image'],
                 ' '.join(cmds))
+            # Left only the extra parameters that are not the bash_command
+            extra_params = { k : self.operator_parameters[k] for k in set(self.operator_parameters) - set(dict.fromkeys({'cmds','image','docker_run'})) }
             operator = BashOperator(
-                task_id = task_id,
-                pool = pool,
-                bash_command = commands
+                bash_command = commands,
+                **extra_params
             )
         else:
+            assert self.operator_parameters['name']
+            assert self.operator_parameters['dag']
             commands = ['./scripts/run.sh']
             commands.append(cmds)
             operator = KubernetesPodOperator(

--- a/airflow_ext/gfw/operators/helper/flexible_operator.py
+++ b/airflow_ext/gfw/operators/helper/flexible_operator.py
@@ -10,7 +10,7 @@ class FlexibleOperator:
         self.operator_parameters = parameters
 
     def build_operator(self, kind):
-        if kind != 'bash' or kind != 'kubernetes':
+        if kind != 'bash' and kind != 'kubernetes':
             raise ValueError('The operators allowed are bash or kubernetes, not <{}>'.format(kind))
         assert self.operator_parameters['task_id']
         assert self.operator_parameters['pool']
@@ -38,11 +38,11 @@ class FlexibleOperator:
             commands = ['./scripts/run.sh']
             commands.append(cmds)
             operator = KubernetesPodOperator(
+                namespace = os.getenv('K8_NAMESPACE'),
                 image = self.operator_parameters['image'],
                 name = self.operator_parameters['name'],
                 dag = self.operator_parameters['dag'],
                 cmds = commands,
-                namespace = os.getenv('K8_NAMESPACE'),
                 task_id = task_id,
                 pool = pool,
                 get_logs = True,

--- a/airflow_ext/gfw/operators/helper/flexible_operator.py
+++ b/airflow_ext/gfw/operators/helper/flexible_operator.py
@@ -15,20 +15,20 @@ class FlexibleOperator:
             raise ValueError('The operators allowed are bash or kubernetes, not <{}>'.format(kind))
         assert self.operator_parameters['task_id']
         assert self.operator_parameters['pool']
-        assert self.operator_parameters['cmds']
+        assert self.operator_parameters['arguments']
         assert self.operator_parameters['image']
         task_id = self.operator_parameters['task_id']
         pool = self.operator_parameters['pool']
-        cmds = self.operator_parameters['cmds']
+        arguments = self.operator_parameters['arguments']
         operator = None
         if kind == 'bash':
             assert self.operator_parameters['docker_run']
             commands = '{} {} {}'.format(
                 self.operator_parameters['docker_run'],
                 self.operator_parameters['image'],
-                ' '.join(cmds))
+                ' '.join(arguments))
             # Left only the extra parameters that are not the bash_command
-            extra_params = { k : self.operator_parameters[k] for k in set(self.operator_parameters) - set(dict.fromkeys({'cmds','image','docker_run','name','dag'})) }
+            extra_params = { k : self.operator_parameters[k] for k in set(self.operator_parameters) - set(dict.fromkeys({'arguments','image','docker_run','name','dag'})) }
             operator = BashOperator(
                 bash_command = commands,
                 **extra_params
@@ -36,9 +36,6 @@ class FlexibleOperator:
         else:
             assert self.operator_parameters['name']
             assert self.operator_parameters['dag']
-            # some pipelines has file run and not run.sh
-            run_path='./scripts/run.sh' if os.path.isfile('./scripts/run.sh') else './scripts/run'
-            self.operator_parameters['cmds'].insert(0, run_path)
             self.operator_parameters.update(get_logs=True, in_cluster=True)
             # Left only the extra parameters that are not the kubernetes_command
             extra_params = { k : self.operator_parameters[k] for k in set(self.operator_parameters) - set(dict.fromkeys({'image','docker_run','name'})) }

--- a/airflow_ext/gfw/operators/helper/flexible_operator.py
+++ b/airflow_ext/gfw/operators/helper/flexible_operator.py
@@ -1,6 +1,7 @@
 from airflow.contrib.operators.kubernetes_pod_operator import KubernetesPodOperator
 from airflow.operators.bash_operator import BashOperator
 
+import logging
 import os
 import os.path
 
@@ -29,6 +30,7 @@ class FlexibleOperator:
                 ' '.join(arguments))
             # Left only the extra parameters that are not the bash_command
             extra_params = { k : self.operator_parameters[k] for k in set(self.operator_parameters) - set(dict.fromkeys({'arguments','image','docker_run','name','dag'})) }
+            logging.info('Running BashOperator(commands={}, {})'.format(commands, ', '.join(['{0}={1}'.format(k,v) for k,v in extra_params.iteritems()])))
             operator = BashOperator(
                 bash_command = commands,
                 **extra_params
@@ -38,7 +40,8 @@ class FlexibleOperator:
             assert self.operator_parameters['dag']
             self.operator_parameters.update(get_logs=True, in_cluster=True, pool='k8operators_limit')
             # Left only the extra parameters that are not the kubernetes_command
-            extra_params = { k : self.operator_parameters[k] for k in set(self.operator_parameters) - set(dict.fromkeys({'image','docker_run','name','pool'})) }
+            extra_params = { k : self.operator_parameters[k] for k in set(self.operator_parameters) - set(dict.fromkeys({'image','docker_run','name'})) }
+            logging.info('Running KubernetesPodOperator(namespace={}, image={}, name={}, {})'.format(os.getenv('K8_NAMESPACE'), self.operator_parameters['image'], self.operator_parameters['name'], ', '.join(['{0}={1}'.format(k,v) for k,v in extra_params.iteritems()])))
             operator = KubernetesPodOperator(
                 namespace = os.getenv('K8_NAMESPACE'),
                 image = self.operator_parameters['image'],

--- a/airflow_ext/gfw/operators/helper/flexible_operator.py
+++ b/airflow_ext/gfw/operators/helper/flexible_operator.py
@@ -30,7 +30,7 @@ class FlexibleOperator:
                 ' '.join(arguments))
             # Left only the extra parameters that are not the bash_command
             extra_params = { k : self.operator_parameters[k] for k in set(self.operator_parameters) - set(dict.fromkeys({'arguments','image','docker_run','name','dag'})) }
-            logging.info('Running BashOperator(commands={}, {})'.format(commands, ', '.join(['{0}={1}'.format(k,v) for k,v in extra_params.iteritems()])))
+            logging.debug('Running BashOperator(commands={}, {})'.format(commands, ', '.join(['{0}={1}'.format(k,v) for k,v in extra_params.iteritems()])))
             operator = BashOperator(
                 bash_command = commands,
                 **extra_params
@@ -41,7 +41,7 @@ class FlexibleOperator:
             self.operator_parameters.update(get_logs=True, in_cluster=True, pool='k8operators_limit')
             # Left only the extra parameters that are not the kubernetes_command
             extra_params = { k : self.operator_parameters[k] for k in set(self.operator_parameters) - set(dict.fromkeys({'image','docker_run','name'})) }
-            logging.info('Running KubernetesPodOperator(namespace={}, image={}, name={}, {})'.format(os.getenv('K8_NAMESPACE'), self.operator_parameters['image'], self.operator_parameters['name'], ', '.join(['{0}={1}'.format(k,v) for k,v in extra_params.iteritems()])))
+            logging.debug('Running KubernetesPodOperator(namespace={}, image={}, name={}, {})'.format(os.getenv('K8_NAMESPACE'), self.operator_parameters['image'], self.operator_parameters['name'], ', '.join(['{0}={1}'.format(k,v) for k,v in extra_params.iteritems()])))
             operator = KubernetesPodOperator(
                 namespace = os.getenv('K8_NAMESPACE'),
                 image = self.operator_parameters['image'],

--- a/setup.py
+++ b/setup.py
@@ -21,11 +21,12 @@ DEPENDENCIES = [
     "pytest",
     "python-dateutil",
     "pytz",
-    "udatetime"
+    "udatetime",
+    "tzlocal==1.5.1"
 ]
 
 AIRFLOW_DEPENDENCIES = [
-    "google-api-python-client==1.7.9",
+    "google-api-python-client",
     "snakebite"
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ DEPENDENCIES = [
 ]
 
 AIRFLOW_DEPENDENCIES = [
-    "google-api-python-client",
+    "google-api-python-client==1.7.9",
     "snakebite"
 ]
 


### PR DESCRIPTION
Adds the `FlexibleOperator` that let you switch between a `BashOperator` and a `KubernetesPodOperator` setting the value of a Airflow Variable.

Also includes a fix for `apache-airflow==1.10.2`, pinning the `tzlocal` lib to version `1.5.1`

Related with> https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1100