### PR TITLE
Avoids hardcore of pool for kubernetesPodOperator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,17 +8,16 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
-## v0.0.3 - 2019-08-05
-
-  * [#1100](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1100): Changes
-    Avoiding hardcore of pool for kubernetesPodOperator.
-
-
 ## v0.0.2 - 2019-08-05
 
   * [#1100](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1100): Adds
     a FlexibleOperator that could change easily from BashOperator to
     KubernetesPodOperator and fixes the build issue with `tzlocal` lib.
+
+  * [#1100](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1100): Changes
+    Avoiding hardcore of pool for kubernetesPodOperator when instances a
+    FlexibleOperator.
+
 
 ## v0.0.1 - 2019-01-22
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,12 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## v0.0.3 - 2019-08-05
+
+  * [#1100](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1100): Changes
+    Avoiding hardcore of pool for kubernetesPodOperator.
+
+
 ## v0.0.2 - 2019-08-05
 
   * [#1100](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1100): Adds

--- a/airflow_ext/__init__.py
+++ b/airflow_ext/__init__.py
@@ -3,7 +3,7 @@ Airflow extension for GFW pipelines.
 """
 
 
-__version__ = '0.0.3'
+__version__ = '0.0.2'
 __author__ = 'Matias Piano'
 __email__ = 'matias@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/airflow-gfw'

--- a/airflow_ext/__init__.py
+++ b/airflow_ext/__init__.py
@@ -3,7 +3,7 @@ Airflow extension for GFW pipelines.
 """
 
 
-__version__ = '0.0.2'
+__version__ = '0.0.3'
 __author__ = 'Matias Piano'
 __email__ = 'matias@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/airflow-gfw'

--- a/airflow_ext/gfw/operators/helper/flexible_operator.py
+++ b/airflow_ext/gfw/operators/helper/flexible_operator.py
@@ -15,11 +15,9 @@ class FlexibleOperator:
         if kind != 'bash' and kind != 'kubernetes':
             raise ValueError('The operators allowed are bash or kubernetes, not <{}>'.format(kind))
         assert self.operator_parameters['task_id']
-        assert self.operator_parameters['pool']
         assert self.operator_parameters['arguments']
         assert self.operator_parameters['image']
         task_id = self.operator_parameters['task_id']
-        pool = self.operator_parameters['pool']
         arguments = self.operator_parameters['arguments']
         operator = None
         if kind == 'bash':

--- a/airflow_ext/gfw/operators/helper/flexible_operator.py
+++ b/airflow_ext/gfw/operators/helper/flexible_operator.py
@@ -38,7 +38,7 @@ class FlexibleOperator:
         else:
             assert self.operator_parameters['name']
             assert self.operator_parameters['dag']
-            self.operator_parameters.update(get_logs=True, in_cluster=True, pool='k8operators_limit')
+            self.operator_parameters.update(get_logs=True, in_cluster=True)
             # Left only the extra parameters that are not the kubernetes_command
             extra_params = { k : self.operator_parameters[k] for k in set(self.operator_parameters) - set(dict.fromkeys({'image','docker_run','name'})) }
             logging.debug('Running KubernetesPodOperator(namespace={}, image={}, name={}, {})'.format(os.getenv('K8_NAMESPACE'), self.operator_parameters['image'], self.operator_parameters['name'], ', '.join(['{0}={1}'.format(k,v) for k,v in extra_params.iteritems()])))


### PR DESCRIPTION
FlexibleOperator demands the pool arguemnt to be run.
Avoid hardcore of pool for FlexibleOperator

Related with> https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1100