### PR TITLE
Features/1160 notify on failure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
-## v0.0.3 - 2019-11-15
+## v0.0.3 - 2019-11-21
 
 ### Changed
 
@@ -20,6 +20,7 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
   * [#1160](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1160): Adds
     google-cloud-storage lirary to run test for DataFlowDirectRunnnerOperator.
+    SlackWebHookOperator to send notifications when a task fails.
 
 ## v0.0.2 - 2019-08-05
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,11 +8,28 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## v0.0.3 - 2019-11-15
+
+### Changed
+
+  * [#1160](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1160): Changes
+    the `Apache Airflow` version from `1.10.2` to `1.10.5`.
+    Set the default pool for DataFlowDirectRunnerOperator the Pool.DEFAULT_POOL_NAME.
+
+### Added
+
+  * [#1160](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1160): Adds
+    google-cloud-storage lirary to run test for DataFlowDirectRunnnerOperator.
+
 ## v0.0.2 - 2019-08-05
+
+### Added
 
   * [#1100](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1100): Adds
     a FlexibleOperator that could change easily from BashOperator to
     KubernetesPodOperator and fixes the build issue with `tzlocal` lib.
+
+### Changed
 
   * [#1100](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1100): Changes
     Avoiding hardcore of pool for kubernetesPodOperator when instances a

--- a/airflow_ext/__init__.py
+++ b/airflow_ext/__init__.py
@@ -3,7 +3,7 @@ Airflow extension for GFW pipelines.
 """
 
 
-__version__ = '0.0.2'
+__version__ = '0.0.3'
 __author__ = 'Matias Piano'
 __email__ = 'matias@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/airflow-gfw'

--- a/airflow_ext/gfw/config.py
+++ b/airflow_ext/gfw/config.py
@@ -100,6 +100,7 @@ def default_args(config):
         'write_disposition': 'WRITE_TRUNCATE',
         'allow_large_results': True,
         'on_failure_callback': failure_callback_gfw,
+        'on_retry_callback': failure_callback_gfw,
     }
 
     return args

--- a/airflow_ext/gfw/operators/dataflow_operator.py
+++ b/airflow_ext/gfw/operators/dataflow_operator.py
@@ -1,10 +1,11 @@
-import re
-
-from airflow.contrib.operators.dataflow_operator import DataFlowPythonOperator
-from airflow.contrib.operators.dataflow_operator import GoogleCloudBucketHelper
 from airflow.contrib.hooks.gcp_dataflow_hook import DataFlowHook
 from airflow.contrib.hooks.gcp_dataflow_hook import _Dataflow
+from airflow.contrib.operators.dataflow_operator import DataFlowPythonOperator
+from airflow.contrib.operators.dataflow_operator import GoogleCloudBucketHelper
+from airflow.models.pool import Pool
 from airflow.utils.decorators import apply_defaults
+
+import re
 
 
 class DataFlowDirectRunnerHook(DataFlowHook):
@@ -25,8 +26,6 @@ class DataFlowDirectRunnerOperator(DataFlowPythonOperator):
 
     @apply_defaults
     def __init__(self, *args, **kwargs):
-        self._pool = None
-
         super(DataFlowDirectRunnerOperator, self).__init__(*args, **kwargs)
 
     @property
@@ -41,7 +40,7 @@ class DataFlowDirectRunnerOperator(DataFlowPythonOperator):
 
     @property
     def pool(self):
-        return self._pool if self._pool else self._default_pool
+        return self._pool if self._pool != Pool.DEFAULT_POOL_NAME else self._default_pool
 
     @pool.setter
     def pool(self, v):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from setuptools import setup
 
 
 DEPENDENCIES = [
-    "apache-airflow==1.10.2",
+    "apache-airflow==1.10.5",
     "cryptography",
     "funcsigs==1.0.0",
     "kubernetes==8.0.1",
@@ -22,7 +22,7 @@ DEPENDENCIES = [
     "python-dateutil",
     "pytz",
     "udatetime",
-    "tzlocal==1.5.1"
+    "google-cloud-storage~=1.16"
 ]
 
 AIRFLOW_DEPENDENCIES = [

--- a/tests/test_airflow.py
+++ b/tests/test_airflow.py
@@ -1,18 +1,19 @@
-import pytest
-from datetime import timedelta
-import os
-
 from airflow import configuration, DAG
+from airflow.models import Variable
+from airflow.operators.dummy_operator import DummyOperator
+from airflow.operators.python_operator import PythonOperator
 from airflow.utils.db import initdb
 from airflow.utils.state import State
 from airflow.utils.timezone import datetime
 from airflow.utils.timezone import utcnow
-from airflow.operators.dummy_operator import DummyOperator
-from airflow.operators.python_operator import PythonOperator
-from airflow.models import Variable
-from airflow_ext.gfw.operators.python_operator import ExecutionDateBranchOperator
-from airflow_ext.gfw.operators.dataflow_operator import DataFlowDirectRunnerOperator
+
 from airflow_ext.gfw.models import DagFactory
+from airflow_ext.gfw.operators.dataflow_operator import DataFlowDirectRunnerOperator
+from airflow_ext.gfw.operators.python_operator import ExecutionDateBranchOperator
+
+from datetime import timedelta
+import os
+import pytest
 
 DEFAULT_DATE = datetime(2018, 1, 1)
 INTERVAL = timedelta(hours=24)


### PR DESCRIPTION
Related with> https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1160

Tests passed.

* Changes the `Apache Airflow` version from `1.10.2` to `1.10.5`.
* Set the default pool for DataFlowDirectRunnerOperator the Pool.DEFAULT_POOL_NAME. It was updated in the upgrade of Apache Airflow.
* Adds `google-cloud-storage` lirary to run test for DataFlowDirectRunnnerOperator.
* Adds SlackWebHookOperator to send notifications when a task fails.
