### PR TITLE
Added the missing return to build docker task

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,13 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## v0.0.7 - 2020-01-22
+
+### Added
+
+  * [#1178](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1178): Adds
+    missing return of the FlexibleOperator operator.
+
 ## v0.0.6 - 2019-12-19
 
 ### Changed

--- a/airflow_ext/__init__.py
+++ b/airflow_ext/__init__.py
@@ -3,7 +3,7 @@ Airflow extension for GFW pipelines.
 """
 
 
-__version__ = '0.0.6'
+__version__ = '0.0.7'
 __author__ = 'Matias Piano'
 __email__ = 'matias@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/airflow-gfw'

--- a/airflow_ext/gfw/models.py
+++ b/airflow_ext/gfw/models.py
@@ -42,7 +42,7 @@ class DagFactory(object):
         This behavior is controlled by the `FLEXIBLE_OPERATOR` airflow
         variable, which may be either `bash` or `kubernetes`.
         """
-        FlexibleOperator(params).build_operator(self.flexible_operator)
+        return FlexibleOperator(params).build_operator(self.flexible_operator)
 
     def source_sensor_date_nodash(self):
         if self.schedule_interval == '@daily':


### PR DESCRIPTION
Little change.
There is needed to access to the operator to put it in the DAG dependency tree.

Related with> https://github.com/GlobalFishingWatch/GFW-Tasks/issues/1178