### PR TITLE
Features/51 update apache airflow version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,13 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## v1.0.2 - 2020-04-24
+
+### Changed
+
+  * [GlobalFishingWatch/gfw-eng-tasks#51](https://github.com/GlobalFishingWatch/gfw-eng-tasks/issues/51): Changes
+    use of Apache Airflow from `1.10.5` to `1.10.10`.
+
 ## v1.0.1 - 2020-03-31
 
 ### Added

--- a/airflow_ext/__init__.py
+++ b/airflow_ext/__init__.py
@@ -3,7 +3,7 @@ Airflow extension for GFW pipelines.
 """
 
 
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 __author__ = 'Matias Piano'
 __email__ = 'matias@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/airflow-gfw'

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from setuptools import setup
 
 
 DEPENDENCIES = [
-    "apache-airflow==1.10.5",
+    "apache-airflow==1.10.10",
     "cryptography",
     "funcsigs==1.0.0",
     "kubernetes==8.0.1",


### PR DESCRIPTION
Update the Apache Airflow lib version from `1.10.5` to `1.10.10`.

Related with> https://github.com/GlobalFishingWatch/gfw-eng-tasks/issues/51