### PR TITLE
PIPELINE-240: Adds source_date_range_nodash method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,19 +8,27 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## v1.1.0 - 2020-11-13
+
+### Added
+
+  * [PIPELINE-155](https://globalfishingwatch.atlassian.net/browse/PIPELINE-155):
+    Adds a new method to obtain the nodash version of `source_date_range`,
+    useful when dealing with date-sharded bq inputs
+
 ## v1.0.4 - 2020-08-04
 
 ### Removed
 
   * [GlobalFishingWatch/gfw-eng-tasks#143](https://github.com/GlobalFishingWatch/gfw-eng-tasks/issues/143): Removes
-    * invalid arguments (`proejct_id` and `dataset_id`) passed to `BigQueryCheckOperator`.
+    invalid arguments (`proejct_id` and `dataset_id`) passed to `BigQueryCheckOperator`.
 
 ## v1.0.3 - 2020-06-05
 
 ### Added
 
   * [GlobalFishingWatch/gfw-eng-tasks#105](https://github.com/GlobalFishingWatch/gfw-eng-tasks/issues/105): Adds
-    * table partition check when using `check_tables` or `check_table` in Airflow Variables.
+    table partition check when using `check_tables` or `check_table` in Airflow Variables.
 
 ## v1.0.2 - 2020-04-24
 

--- a/airflow_ext/__init__.py
+++ b/airflow_ext/__init__.py
@@ -3,7 +3,7 @@ Airflow extension for GFW pipelines.
 """
 
 
-__version__ = '1.0.4'
+__version__ = '1.1.0'
 __author__ = 'Matias Piano'
 __email__ = 'matias@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/airflow-gfw'

--- a/airflow_ext/gfw/models.py
+++ b/airflow_ext/gfw/models.py
@@ -56,6 +56,17 @@ class DagFactory(object):
             raise ValueError('Unsupported schedule interval {}'.format(
                 self.schedule_interval))
 
+    def source_date_range_nodash(self):
+        if self.schedule_interval == '@daily':
+            return '{{ ds_nodash }}', '{{ ds_nodash }}'
+        elif self.schedule_interval == '@monthly':
+            return self.config['first_day_of_month_nodash'], self.config['last_day_of_month_nodash']
+        elif self.schedule_interval == '@yearly':
+            return self.config['first_day_of_year_nodash'], self.config['last_day_of_year_nodash']
+        else:
+            raise ValueError('Unsupported schedule interval {}'.format(
+                self.schedule_interval))
+
     def source_date_range(self):
         if self.schedule_interval == '@daily':
             return '{{ ds }}', '{{ ds }}'

--- a/tests/test_airflow.py
+++ b/tests/test_airflow.py
@@ -148,6 +148,40 @@ class TestAirflow:
         dag = dag_factory(pipeline=dag_config).build('test_dag')
 
     @pytest.mark.parametrize("schedule_interval,expected", [
+        ('@daily', ('2018-01-01', '2018-01-01')),
+        ('@monthly', ('2018-01-01', '2018-01-31')),
+        ('@yearly', ('2018-01-01', '2018-12-31')),
+    ])
+    def test_source_date_range(self, schedule_interval, expected, dag_factory, dag_config):
+        schedule_interval_name = schedule_interval.replace('@', '')
+        factory = dag_factory(pipeline=dag_config, schedule_interval=schedule_interval)
+        dag = factory.build('test_source_date_range{}'.format(schedule_interval_name))
+        task = self.assert_expected_task(
+            task_id='test_source_date_range_{}'.format(schedule_interval_name),
+            expected=expected,
+            templated=factory.source_date_range(),
+            dag=dag
+        )
+        task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+
+    @pytest.mark.parametrize("schedule_interval,expected", [
+        ('@daily', ('20180101', '20180101')),
+        ('@monthly', ('20180101', '20180131')),
+        ('@yearly', ('20180101', '20181231')),
+    ])
+    def test_source_date_range_nodash(self, schedule_interval, expected, dag_factory, dag_config):
+        schedule_interval_name = schedule_interval.replace('@', '')
+        factory = dag_factory(pipeline=dag_config, schedule_interval=schedule_interval)
+        dag = factory.build('test_source_date_range_nodash{}'.format(schedule_interval_name))
+        task = self.assert_expected_task(
+            task_id='test_source_date_range_nodash_{}'.format(schedule_interval_name),
+            expected=expected,
+            templated=factory.source_date_range_nodash(),
+            dag=dag
+        )
+        task.run(start_date=DEFAULT_DATE, end_date=DEFAULT_DATE)
+
+    @pytest.mark.parametrize("schedule_interval,expected", [
         ('@daily', '20180101'),
         ('@monthly', '20180131'),
         ('@yearly', '20181231'),


### PR DESCRIPTION
Related to https://globalfishingwatch.atlassian.net/browse/PIPELINE-240

This method is useful when creating operators depending on queries over date-sharded tables. Right now we are doing the dash to nodash conversion on every single script that deals with date-sharded tables (that's 80% of them).