### PR TITLE
Fixes build of image and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,20 @@ cache:
   directories:
   - ~/.cache/pip
 
+services:
+  - docker
+
 python:
-- 2.7
+- 3.7
 
 env:
 - SLUGIFY_USES_TEXT_UNIDECODE=yes
 
 install:
-- pip install -e .
+- docker-compose build
 
 script:
-- py.test tests
+- docker-compose run test
 
 notifications:
   slack:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,10 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
     Adds a new method to obtain the nodash version of `source_date_range`,
     useful when dealing with date-sharded bq inputs
 
+  * [PIPELINE-241](https://globalfishingwatch.atlassian.net/browse/PIPELINE-241):
+    Adds pin over `marshmallow-sqlalchemy` and `marshmallow` packages to create image without errors.
+    Also fixes travis and add build reference in the `README.md`.
+
 ## v1.0.4 - 2020-08-04
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+master: [![Build Status](https://travis-ci.org/GlobalFishingWatch/airflow-gfw.svg?branch=master)](https://travis-ci.org/GlobalFishingWatch/airflow-gfw)
+develop: [![Build Status](https://travis-ci.org/GlobalFishingWatch/airflow-gfw.svg?branch=develop)](https://travis-ci.org/GlobalFishingWatch/airflow-gfw)
+
 # airflow-gfw
 
 It is a package providing an [Airflow](https://airflow.apache.org/) extension for GFW pipeline.

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,8 @@ from setuptools import setup
 
 DEPENDENCIES = [
     "apache-airflow==1.10.10",
+    "marshmallow==2.21.0",
+    "marshmallow-sqlalchemy==0.23.1",
     "cryptography",
     "funcsigs==1.0.0",
     "kubernetes==8.0.1",


### PR DESCRIPTION
* This PR updates the `travis` version and fixes the `YAM`L, also I enabled the run of the test automatically over the `travis` site.
* Added the build status reference in the `README.md` file.
* Fixes the image build.

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-241