### PR TITLE
Feature/pipeline 393

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,16 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## v1.4.0 - 2021-05-13
+
+### Changed
+
+  * [PIPELINE-393](https://globalfishingwatch.atlassian.net/browse/PIPELINE-393): Changes
+    do NOT reattach to pod after restart kubernetes cluster. This will let
+    create a new pod to start processing the tasks from scratch and avoid
+    having last issues on keeping requesting the pod and get confusion when
+    it's declared as success state.
+
 ## v1.3.0 - 2021-04-27
 
 ### Added

--- a/airflow_ext/__init__.py
+++ b/airflow_ext/__init__.py
@@ -3,7 +3,7 @@ Airflow extension for GFW pipelines.
 """
 
 
-__version__ = '1.3.0'
+__version__ = '1.4.0'
 __author__ = 'Matias Piano'
 __email__ = 'matias@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/airflow-gfw'

--- a/airflow_ext/gfw/config.py
+++ b/airflow_ext/gfw/config.py
@@ -54,15 +54,16 @@ def failure_callback_gfw(context):
     :type context: dict
     """
     ti = context['task_instance']
+    default_owner = Variable.get('default_slack_task_owner', 'matias')
+    # owner = config.get('owner',False)
+    owner = False
+    mention = lambda x: ','.join(['@'+user for user in x.split(',')])
     message = ':red_circle: TASK FAILS:\n' \
-              'DAG:    {}\n' \
-              'TASKS:  {}\n' \
-              'Log-URL: {}\n' \
-              'Reason: {}\n' \
-        .format(ti.dag_id,
-                ti.task_id,
-                ti.log_url,
-                context['exception'])
+              f'Owner:   {mention(owner if owner else default_owner)}\n' \
+              f'DAG:     {ti.dag_id}\n' \
+              f'TASKS:   {ti.task_id}\n' \
+              f'Log-URL: {ti.log_url}\n' \
+              f'Reason:  {context["exception"]}\n'
 
     slack_webhook_token = BaseHook.get_connection(SLACK_CONN_ID).password
 

--- a/airflow_ext/gfw/config.py
+++ b/airflow_ext/gfw/config.py
@@ -55,11 +55,17 @@ def failure_callback_gfw(context):
     """
     ti = context['task_instance']
     default_owner = Variable.get('default_slack_task_owner', 'matias')
-    # owner = config.get('owner',False)
-    owner = False
-    mention = lambda x: ','.join(['@'+user for user in x.split(',')])
+    try:
+        # Gets Airflow Variable from Dag id.
+        sanitizeAirflowVarName = lambda x: '_'.join(x.split('.')[0].split('_')[:-1]) if any(d in x.split('.')[0].split('_') for d in ["daily","monthly","yearly"]) else x.split('.')[0]
+        dagVariables = Variable.get(sanitizeAirflowVarName(ti.dag_id), deserialize_json=True)
+        owner = dagVariables.get('slack_task_owner', default_owner) if dagVariables else default_owner
+    except KeyError:
+        owner = default_owner
+    mention = lambda x: ','.join(['@'+user.strip() for user in x.split(',')])
+
     message = ':red_circle: TASK FAILS:\n' \
-              f'Owner:   {mention(owner if owner else default_owner)}\n' \
+              f'Owner:   {mention(owner)}\n' \
               f'DAG:     {ti.dag_id}\n' \
               f'TASKS:   {ti.task_id}\n' \
               f'Log-URL: {ti.log_url}\n' \

--- a/airflow_ext/gfw/operators/helper/flexible_operator.py
+++ b/airflow_ext/gfw/operators/helper/flexible_operator.py
@@ -36,7 +36,7 @@ class FlexibleOperator:
         else:
             assert self.operator_parameters['name']
             assert self.operator_parameters['dag']
-            self.operator_parameters.update(get_logs=True, in_cluster=True)
+            self.operator_parameters.update(get_logs=True, in_cluster=True, reattach_on_restart=False)
             # Left only the extra parameters that are not the kubernetes_command
             extra_params = { k : self.operator_parameters[k] for k in set(self.operator_parameters) - set(dict.fromkeys({'image','docker_run','name'})) }
             logging.debug('Running KubernetesPodOperator(namespace={}, image={}, name={}, {})'.format(os.getenv('K8_NAMESPACE'), self.operator_parameters['image'], self.operator_parameters['name'], ', '.join(['{0}={1}'.format(k,v) for k,v in list(extra_params.items())])))

--- a/tests/test_airflow.py
+++ b/tests/test_airflow.py
@@ -25,7 +25,7 @@ INTERVAL = timedelta(hours=24)
 # NB:  See the commennts on conftest.py about how AIRFLOW_HOME gets initialized
 @pytest.fixture(scope='module')
 def airflow_init_db(airflow_home):
-    configuration.load_test_config()
+    configuration.conf.load_test_config()
     initdb()
 
 


### PR DESCRIPTION
    do NOT reattach to pod after restart kubernetes cluster. This will let
    create a new pod to start processing the tasks from scratch and avoid
    having last issues on keeping requesting the pod and get confusion when
    it's declared as success state.

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-393